### PR TITLE
Use rollup to create UMD bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.0.2",
   "description": "Ultra small CSS in JS library in 0.4 KB for Picodom",
   "main": "dist/picostyle.js",
+  "jsnext:main": "src/index.js",
+  "module": "src/index.js",
   "scripts": {
-    "build": "(rm -rf dist || true) && mkdir dist && npm run compress",
-    "compress": "uglifyjs src/index.js -o dist/picostyle.js -c toplevel,sequences=false -m toplevel",
     "start": "webpack-dev-server",
-    "test": "npm run build && bundlesize"
+    "test": "npm run build && bundlesize",
+    "build": "rollup -cm -n picostyle -f umd -i src/index.js -o dist/picostyle.js"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,9 @@
     "babel-preset-env": "^1.6.0",
     "bundlesize": "^0.13.2",
     "picodom": "0.0.8",
+    "rollup": "^0.45.2",
+    "rollup-plugin-buble": "^0.15.0",
+    "rollup-plugin-uglify": "^2.0.1",
     "uglify-es": "^3.0.27",
     "webpack": "^3.4.1",
     "webpack-dev-server": "^2.6.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,9 @@
+import uglify from "rollup-plugin-uglify"
+import buble from "rollup-plugin-buble"
+
+export default {
+  plugins: [buble(), uglify({})],
+  globals: {
+    picodom: "picodom"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-var h = require("picodom").h
-
+var { h } = picodom
 var _id = 0
 var insert = _ => _
 var cache = {}
@@ -37,4 +36,4 @@ if (window) {
   insert = rule => sheet.insertRule(rule, sheet.cssRules.length)
 }
 
-module.exports = tag => (...decls) => (_, children) => h(tag, { class: decls.map(decl => parse(decl)) }, children)
+export default tag => (...decls) => (_, children) => h(tag, { class: decls.map(decl => parse(decl)) }, children)


### PR DESCRIPTION
This makes it easier to share and prototype on CodePen, JSFiddle, etc.

Also added [`jsnext:main`](https://github.com/rollup/rollup/wiki/jsnext%3Amain) and [`module`](https://github.com/rollup/rollup/wiki/pkg.module) to `package.json`.

```json
"main": "dist/picostyle.js",
"jsnext:main": "src/index.js",
"module": "src/index.js",
```