### PR TITLE
Output non-atomized styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > Most lightweight CSS in JS library ever.
 
-[![507B gzip][gzip-badge]][bundlesize]
+[![476B gzip][gzip-badge]][bundlesize]
 
-[gzip-badge]: https://img.shields.io/badge/bundled%20&%20gzip-507%20B-brightgreen.svg
+[gzip-badge]: https://img.shields.io/badge/bundled%20&%20gzip-476%20B-brightgreen.svg
 [bundlesize]: https://github.com/siddharthkp/bundlesize
 
 <div align="center">
@@ -17,7 +17,7 @@
 ## Features
 
 - **🚀 Most lightweight CSS in JS library ever**: Only 0.5 KB (bundled & gzipped)
-- **⚡️ Extreme high performance**: Optimized by Virtual CSS inspired by [Styletron](https://ryantsao.com/blog/virtual-css-with-styletron)
+- **👏 Zero dependency**: Optimized by Virtual CSS inspired by [Styletron](https://ryantsao.com/blog/virtual-css-with-styletron)
 - **💅 Styled components**: Returns styled components like [styled-components](https://www.styled-components.com/) that everyone loves :)
 - **❤️ For HyperApp**: [HyperApp](https://github.com/hyperapp/hyperapp) is a JavaScript library for building frontend applications
 - **❤️ For Picodom**: [Picodom](https://github.com/picodom/picodom) is just 1 KB Virtual DOM builder and patch algorithm


### PR DESCRIPTION
## What

Changed to output non-atomized styles.

## Why

Now, Picostyle has a bug around setting classes (https://github.com/morishitter/picostyle/issues/5). It is very hard to fix this bug while using atomized outputs. [Styletron takes well care of it](https://github.com/rtsao/styletron/blob/master/packages/styletron-utils/src/shorthand-map.js). It is awsome, but too fat.

Picostyle's concept is **Ultra small**. If I merge this PR, we will get large output styles from Picostyle, but Picostyle will be more simple. (If we need more optimized output CSS, we can use Styletron.) And, it will output a single class, so we can debug styles easily when crafting websites.