### PR TITLE
fix types according with the default import

### DIFF
--- a/picostyle.d.ts
+++ b/picostyle.d.ts
@@ -21,5 +21,5 @@ interface Styles {
     [key: string]: any;
 }
 
-export function picostyle(vdom: createNode): (element: string | Component<object>) =>
+export default function picostyle(vdom: createNode): (element: string | Component<object>) =>
     (styles: Styles | StyleProps) => (...children: any[]) => VNode | string | number | null;

--- a/test/types/basic.test.ts
+++ b/test/types/basic.test.ts
@@ -1,5 +1,5 @@
 import {h} from "ultradom";
-import {picostyle} from "../..";
+import picostyle from "../..";
 
 const style = picostyle(h);
 

--- a/test/types/basic.test.tsx
+++ b/test/types/basic.test.tsx
@@ -1,5 +1,5 @@
 import {h, patch} from "ultradom";
-import {picostyle} from "../../";
+import picostyle from "../../";
 
 const ps = picostyle(h);
 


### PR DESCRIPTION
Doing a example I realized that the types were wrong because you export picostyle like this `export default function(h)` instead of this `export picostyle(h)` because of this I had to do the same in the types, otherwise it doesn't work.

