### PR TITLE
Class bundling and better caching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,10 +50,9 @@ export default function(h) {
       return function(attributes, children) {
         attributes = attributes || {}
         children = attributes.children || children
-        var key = serialize(attributes)
-        cache[key] ||
-          (cache[key] =
-            (isDeclsFunction && parse(decls(attributes))) || parse(decls))
+        var nodeDecls = isDeclsFunction ? decls(attributes) : decls
+        var key = serialize(nodeDecls)
+        cache[key] || (cache[key] = parse(nodeDecls))
         attributes.class = [attributes.class, cache[key]]
           .filter(Boolean)
           .join(" ")

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ function hyphenate(str) {
 }
 
 function insert(rule) {
-  sheet.insertRule(rule, 0)
+  sheet.insertRule(rule, sheet.cssRules.length)
 }
 
 function createRule(className, decls, media) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,11 +54,10 @@ export default function(h) {
         cache[key] ||
           (cache[key] =
             (isDeclsFunction && parse(decls(attributes))) || parse(decls))
-        var node = h(nodeName, attributes, children)
-        node.attributes.class = [attributes.class, cache[key]]
+        attributes.class = [attributes.class, cache[key]]
           .filter(Boolean)
           .join(" ")
-        return node
+        return h(nodeName, attributes, children)
       }
     }
   }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -134,11 +134,10 @@ test("class name bundling", () => {
     backgroundColor: "red"
   })
 
-  // BUG: Fix this test when https://github.com/picostyle/picostyle/pull/26 is resolved
   expectClassNameAndCssText(
     Test(),
-    "p9 p9 pa",
-    ".pa {background-color: red;},.p9 {color: white;}"
+    "p9 pa",
+    ".pa {color: white;},.p9 {background-color: red;}"
   )
 })
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,7 +11,11 @@ global.document = dom.window.document
 const style = (nodeName, decls) => picostyle(h)(nodeName)(decls)
 
 function cssRulesAsText(stylesheet) {
-  return [].concat(stylesheet.cssRules).reverse().map(rule => rule.cssText).join()
+  return []
+    .concat(stylesheet.cssRules)
+    .reverse()
+    .map(rule => rule.cssText)
+    .join()
 }
 
 function removeRules(stylesheet) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,7 +11,7 @@ global.document = dom.window.document
 const style = (nodeName, decls) => picostyle(h)(nodeName)(decls)
 
 function cssRulesAsText(stylesheet) {
-  return stylesheet.cssRules.map(rule => rule.cssText).join()
+  return [].concat(stylesheet.cssRules).reverse().map(rule => rule.cssText).join()
 }
 
 function removeRules(stylesheet) {


### PR DESCRIPTION
This PR fixes the same problem as #26 and packs an update to the style cache.

Before: the cache was indexed on the attributes. They can vary a lot with no impact on the generated style. This means a new rule is generated for each prop change.

Now:  the cache is indexed using the style object generated with the current props, meaning only one class will be cached for one specific style.

Also, I modified `insert` so that new rules are inserted at the end of the sheet, hence giving them priority over the ones generated before. This allows styles that extend existing styles to actually overwrite them.