### PR TITLE
Custom class names + rule grouping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,16 +7,11 @@ function hyphenate(str) {
 }
 
 function last(group) {
-  var groupRx = new RegExp("\." + group + "(_[0-9]+| .+)?$")
+  var groupRx = new RegExp("^\\." + group + ".*")
+  var rules = Array.from(sheet.cssRules).reverse()
+  var index = rules.findIndex(rule => groupRx.test(rule.selectorText))
 
-  var reverseIndex = []
-    .concat(sheet.cssRules)
-    .reverse()
-    .findIndex(rule => groupRx.test(rule.selectorText))
-
-  return (reverseIndex >= 0)
-    ? sheet.cssRules.length - reverseIndex
-    : sheet.cssRules.length
+  return (index >= 0) ? rules.length - index : rules.length
 }
 
 function insert(rule, group) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,14 @@ function insert(rule, group) {
   sheet.insertRule(rule, lastOf(group))
 }
 
+function isDef(val) {
+  return val !== undefined && val !== null && val !== ''
+}
+
 function createRule(className, decls, media) {
   var newDecls = []
   for (var property in decls) {
-    typeof decls[property] !== "object" &&
+    isDef(decls[property]) && typeof decls[property] !== "object" &&
       newDecls.push(hyphenate(property) + ":" + decls[property] + ";")
   }
   var rule = "." + className + "{" + newDecls.join("") + "}"

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,9 @@ function hyphenate(str) {
 function lastOf(group) {
   var groupRx = new RegExp("^\\." + group + "([^0-9a-zA-Z\\-].*)?$")
   var rules = Array.from(sheet.cssRules).reverse()
-  var index = rules.findIndex(rule => groupRx.test(rule.selectorText))
+  var index = rules.findIndex(function(rule) {
+    return groupRx.test(rule.selectorText)
+  })
   return index >= 0 ? rules.length - index : rules.length
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,10 +7,10 @@ function hyphenate(str) {
 }
 
 function lastOf(group) {
-  var groupRx = new RegExp("^\\." + group + "([^0-9a-zA-Z\-].*)?$")
+  var groupRx = new RegExp("^\\." + group + "([^0-9a-zA-Z\\-].*)?$")
   var rules = Array.from(sheet.cssRules).reverse()
   var index = rules.findIndex(rule => groupRx.test(rule.selectorText))
-  return (index >= 0) ? rules.length - index : rules.length
+  return index >= 0 ? rules.length - index : rules.length
 }
 
 function insert(rule, group) {
@@ -18,13 +18,14 @@ function insert(rule, group) {
 }
 
 function isDef(val) {
-  return val !== undefined && val !== null && val !== ''
+  return val !== undefined && val !== null && val !== ""
 }
 
 function createRule(className, decls, media) {
   var newDecls = []
   for (var property in decls) {
-    isDef(decls[property]) && typeof decls[property] !== "object" &&
+    isDef(decls[property]) &&
+      typeof decls[property] !== "object" &&
       newDecls.push(hyphenate(property) + ":" + decls[property] + ";")
   }
   var rule = "." + className + "{" + newDecls.join("") + "}"
@@ -49,11 +50,11 @@ function parse(group, className, decls, child, media) {
 }
 
 function createClass(className, version) {
-  return (className && version) ? className + '_' + version : className
+  return className && version ? className + "_" + version : className
 }
 
 function cached(cache, group, decls, attributes) {
-  var declsVariation = typeof decls === 'function' ? decls(attributes) : decls
+  var declsVariation = typeof decls === "function" ? decls(attributes) : decls
   var key = serialize(declsVariation)
   if (!cache[key]) {
     cache[key] = createClass(group, Object.keys(cache).length)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -151,7 +151,7 @@ test("decl as function", () => {
   expectClassNameAndCssText(
     Test({ color: "tomato" }),
     "pb_1",
-    ".pb {color: undefined;},.pb_1 {color: tomato;}"
+    ".pb {},.pb_1 {color: tomato;}"
   )
 })
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -9,6 +9,7 @@ global.document = dom.window.document
 
 // picostyle helper function
 const style = (nodeName, decls) => picostyle(h)(nodeName)(decls)
+const styleClass = (nodeName, className, decls) => picostyle(h)(nodeName, className)(decls)
 
 function cssRulesAsText(stylesheet) {
   return stylesheet.cssRules
@@ -149,8 +150,8 @@ test("decl as function", () => {
   })
   expectClassNameAndCssText(
     Test({ color: "tomato" }),
-    "pc",
-    ".pb {color: undefined;},.pc {color: tomato;}"
+    "pb_1",
+    ".pb {color: undefined;},.pb_1 {color: tomato;}"
   )
 })
 
@@ -159,7 +160,7 @@ test("extend component", () => {
   const Test = style(Div, {
     backgroundColor: "red"
   })
-  expectClassNameAndCssText(Test({}), "pd", ".pd {background-color: red;}")
+  expectClassNameAndCssText(Test({}), "pc", ".pc {background-color: red;}")
 })
 
 test("custom class name", () => {
@@ -170,6 +171,27 @@ test("custom class name", () => {
 test("custom class name with variations", () => {
   const Test = picostyle(h)("div", "test")(props => ({ color: props.color || 'red' }))
   expectClassNameAndCssText(Test(), "test", ".test {color: red;}")
-  expectClassNameAndCssText(Test({ color: 'white' }), "test-1", ".test {color: red;},.test-1 {color: white;}")
-  expectClassNameAndCssText(Test({ color: 'black' }), "test-2", ".test {color: red;},.test-1 {color: white;},.test-2 {color: black;}")
+  expectClassNameAndCssText(Test({ color: 'white' }), "test_1", ".test {color: red;},.test_1 {color: white;}")
+  expectClassNameAndCssText(Test({ color: 'black' }), "test_2", ".test {color: red;},.test_1 {color: white;},.test_2 {color: black;}")
 })
+
+test("class name bundling with custom class variation", () => {
+  const Div = styleClass("div", "div", props =>({
+    color: props.color || "white"
+  }))
+  const Test = styleClass(Div, "test", {
+    backgroundColor: "red"
+  })
+
+  expectClassNameAndCssText(
+    Test(),
+    "test div",
+    ".div {color: white;},.test {background-color: red;}"
+  )
+  expectClassNameAndCssText(
+    Test({ color: "purple" }),
+    "test div_1",
+    ".div {color: white;},.div_1 {color: purple;},.test {background-color: red;}"
+  )
+})
+

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -9,12 +9,11 @@ global.document = dom.window.document
 
 // picostyle helper function
 const style = (nodeName, decls) => picostyle(h)(nodeName)(decls)
-const styleClass = (nodeName, className, decls) => picostyle(h)(nodeName, className)(decls)
+const styleClass = (nodeName, className, decls) =>
+  picostyle(h)(nodeName, className)(decls)
 
 function cssRulesAsText(stylesheet) {
-  return stylesheet.cssRules
-    .map(rule => rule.cssText)
-    .join()
+  return stylesheet.cssRules.map(rule => rule.cssText).join()
 }
 
 function removeRules(stylesheet) {
@@ -169,24 +168,26 @@ test("custom class name", () => {
 })
 
 test("custom class name with variations", () => {
-  const Test = styleClass("div", "test", props => ({ color: props.color || "red" }))
+  const Test = styleClass("div", "test", props => ({
+    color: props.color || "red"
+  }))
   expectClassNameAndCssText(Test(), "test", ".test {color: red;}")
 
   expectClassNameAndCssText(
-    Test({ color: 'white' }),
+    Test({ color: "white" }),
     "test_1",
     ".test {color: red;},.test_1 {color: white;}"
   )
 
   expectClassNameAndCssText(
-    Test({ color: 'black' }),
+    Test({ color: "black" }),
     "test_2",
     ".test {color: red;},.test_1 {color: white;},.test_2 {color: black;}"
   )
 })
 
 test("grouping rules by component", () => {
-  const First = styleClass("div", "first", props =>({
+  const First = styleClass("div", "first", props => ({
     color: props.color || "white"
   }))
   const Second = styleClass("div", "second", {
@@ -209,9 +210,9 @@ test("grouping rules by component", () => {
 })
 
 test("potentially conflicting grouping", () => {
-  const P1 = styleClass("div", "p1", props =>({
+  const P1 = styleClass("div", "p1", props => ({
     color: props.color || "white",
-    '>a' : { color: 'blue' }
+    ">a": { color: "blue" }
   }))
   const P12 = styleClass("div", "p12", {
     opacity: 0.5
@@ -229,4 +230,3 @@ test("potentially conflicting grouping", () => {
     ".p1 {color: white;},.p1>a {color: blue;},.p1_1 {color: green;},.p1_1>a {color: blue;},.p1_2 {color: red;},.p1_2>a {color: blue;},.p12 {opacity: 0.5;}"
   )
 })
-

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -164,13 +164,12 @@ test("extend component", () => {
 })
 
 test("custom class name", () => {
-  const Test = picostyle(h)("div", "test")({ color: "white" })
+  const Test = styleClass("div", "test", { color: "white" })
   expectClassNameAndCssText(Test(), "test", ".test {color: white;}")
 })
 
 test("custom class name with variations", () => {
-  const Test = picostyle(h)("div", "test")(props => ({ color: props.color || 'red' }))
-
+  const Test = styleClass("div", "test", props => ({ color: props.color || "red" }))
   expectClassNameAndCssText(Test(), "test", ".test {color: red;}")
 
   expectClassNameAndCssText(

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,9 +11,7 @@ global.document = dom.window.document
 const style = (nodeName, decls) => picostyle(h)(nodeName)(decls)
 
 function cssRulesAsText(stylesheet) {
-  return []
-    .concat(stylesheet.cssRules)
-    .reverse()
+  return stylesheet.cssRules
     .map(rule => rule.cssText)
     .join()
 }
@@ -140,8 +138,8 @@ test("class name bundling", () => {
 
   expectClassNameAndCssText(
     Test(),
-    "p9 pa",
-    ".pa {color: white;},.p9 {background-color: red;}"
+    "pa p9",
+    ".p9 {color: white;},.pa {background-color: red;}"
   )
 })
 
@@ -151,8 +149,8 @@ test("decl as function", () => {
   })
   expectClassNameAndCssText(
     Test({ color: "tomato" }),
-    "pb",
-    ".pb {color: tomato;}"
+    "pc",
+    ".pb {color: undefined;},.pc {color: tomato;}"
   )
 })
 
@@ -161,5 +159,17 @@ test("extend component", () => {
   const Test = style(Div, {
     backgroundColor: "red"
   })
-  expectClassNameAndCssText(Test({}), "pc", ".pc {background-color: red;}")
+  expectClassNameAndCssText(Test({}), "pd", ".pd {background-color: red;}")
+})
+
+test("custom class name", () => {
+  const Test = picostyle(h)("div", "test")({ color: "white" })
+  expectClassNameAndCssText(Test(), "test", ".test {color: white;}")
+})
+
+test("custom class name with variations", () => {
+  const Test = picostyle(h)("div", "test")(props => ({ color: props.color || 'red' }))
+  expectClassNameAndCssText(Test(), "test", ".test {color: red;}")
+  expectClassNameAndCssText(Test({ color: 'white' }), "test-1", ".test {color: red;},.test-1 {color: white;}")
+  expectClassNameAndCssText(Test({ color: 'black' }), "test-2", ".test {color: red;},.test-1 {color: white;},.test-2 {color: black;}")
 })


### PR DESCRIPTION
This started out adding the ability to customize the class names of styled components and ended up fixing some bugs and adding small features.

### Custom class names
```JS
const Title = style("span", "title")({ fontWeight: "bold" })
```
Will give you a 
```HTML
<span class="title">
```
If you do not specify a name, it will fallback to the previous `p*` automatic class name.

### Class name variation
If you use a function for your style, a variation of the base class name of the component will be generated every time a brand new style is detected.
```JSX
const Text = style("span")(props => ({ 
  color: props.color
})

const el = (
  <div>
    <Text>Default</Text>
    <Text color="red">Red</Text>
    <Text color="green">Green</Text>
    <Text color="red">Other Red</Text>
  </div>
)
```
Will generate
```HTML
<div>
  <span class="p1">Default</span>
  <span class="p1_1">Red</span>
  <span class="p1_2">Green</span>
  <span class="p1_1">Other Red</span>
</div>
```

### Rule grouping
Since my last PR, new rules were always added at the end of the sheet in order to give them priority over existing rules. However as some classes are generated only when needed, they were potentially conflicting with other ones that should have had priority.

In order to avoid this scenario, rules that belong to the variations of one styled component are now grouped together in the stylesheet (see [here](https://github.com/jfalxa/picostyle/blob/0c53df3decb94832484d19fa978c7b7b5c3effd5/test/basic.test.js#L212-L231)). 