### PR TITLE
better compatibility with old versions (removed space before">")

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function parse(obj, classname, isInsideObj) {
     prop = hyphenate(prop)
     // Same as typeof value === 'object', but smaller
     if (!value.sub) {
-      if (/^(:| >|\.|\*)/.test(prop)) {
+      if (/^(:|>|\.|\*)/.test(prop)) {
         prop = classname + prop
       }
       // replace & in "&:hover", "p>&"


### PR DESCRIPTION
I've just seen in the docs that there are no spaces before the ">", so i changed the code to respect the docs and have better compatibility with older code using ">".  