### PR TITLE
Allow arrays for property values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function parse(obj, classname, isInsideObj) {
     var value = obj[prop]
     prop = hyphenate(prop)
     // Same as typeof value === 'object', but smaller
-    if (!value.sub) {
+    if (!value.sub && !Array.isArray(value)) {
       if (/^(:|>|\.|\*)/.test(prop)) {
         prop = classname + prop
       }
@@ -34,7 +34,10 @@ function parse(obj, classname, isInsideObj) {
         wrap(parse(value, classname, 1 && !/^@/.test(prop)).join(""), prop)
       )
     } else {
-      arr[0] += prop + ":" + value + ";"
+      value = Array.isArray(value) ? value : [value]
+      value.forEach((value) => {
+        arr[0] += prop + ":" + value + ";"
+      })
     }
   }
   if (!isInsideObj) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -191,6 +191,6 @@ test("create keyframes", () => {
 test("array syntax", () => {
   const Test = style("div", {
     position: ["sticky", "-webkit-sticky"]
-  })
-  expect(cssRulesAsText(document.styleSheets[0])).stringContaining("position")
+  })()
+  expect(cssRulesAsText(document.styleSheets[0])).toMatch("position")
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -187,3 +187,10 @@ test("create keyframes", () => {
 }`
   )
 })
+
+test("array syntax", () => {
+  const Test = style("div", {
+    position: ["sticky", "-webkit-sticky"]
+  })
+  expect(cssRulesAsText(document.styleSheets[0])).stringContaining("position")
+})


### PR DESCRIPTION
This is useful for vendor-prefixing and makes it possible to use
postprocessors like PostcssJs (as suggested in #38 ), which uses an array for multiple property
values.

Example:
`position: ['sticky', '-webkit-sticky']` will become
`position: sticky;
position: -webkit-sticky;` for the browser

Right now such arrays will be ignored completely by Picostyle