### PR TITLE
Add type definition for exported keyframes() function

### DIFF
--- a/picostyle.d.ts
+++ b/picostyle.d.ts
@@ -21,5 +21,7 @@ interface Styles {
     [key: string]: any;
 }
 
+export const keyframes: (obj: StyleProps) => string;
+
 export default function picostyle(vdom: createNode): (element: string | Component<object>) =>
     (styles: Styles | StyleProps) => (...children: any[]) => VNode | string | number | null;


### PR DESCRIPTION
Hi, I found this package very useful and would like to make a contribution. Thanks for creating and maintaining this!

I'm using TypeScript for my projects that use `picostyle` and TS complains about not knowing what keyframes is whenever it's imported: `"TS2305: Module "picostyle" has no exported member 'keyframes'.`.

e.g.
```typescript
import {keyframes} from 'picostyle';

...

keyframes({ ... });
```

My fix for this is to add the correct type to the `picostyle.d.ts` file. A very small change.
I'm using IntelliJ IDEA as my editor and after adding that line, its TS compiler thread no longer complains about `keyframes()`.