### PR TITLE
allow to override base styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default function(h) {
         var nodeDecls = typeof decls == "function" ? decls(attributes) : decls
         var key = JSON.stringify(nodeDecls)
         cache[key] || (cache[key] = createStyle(nodeDecls))
-        attributes.class = [attributes.class, cache[key]]
+        attributes.class = [cache[key], attributes.class]
           .filter(Boolean)
           .join(" ")
         return h(nodeName, attributes, children)

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -142,7 +142,7 @@ test("class name bundling", () => {
 
   expectClassNameAndCssText(
     Test(),
-    "p9 p10",
+    "p10 p9",
     ".p10 {color: white;},.p9 {background-color: red;}"
   )
 })


### PR DESCRIPTION
This pull request allows to override base styles on conflicting properties the same way it works in styled-components. 

In the scenario below I'd expect color to be red but in the current version it's white.
  ```javascript
  const Alert = style("div", {
    color: "white"
  })
  const AlertDanger = style(Alert, {
    color: "red"
  })
```