### PR TITLE
fixing component styling documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const Wrapper = style("div")({
 })
 
 // Styling an un-styled component
-const Component = text => h("h1", {}, text)
+const Component = (props, text) => h("h1", props, text)
 const Text = style(Component)({
   color: "#fff",
 })


### PR DESCRIPTION
This is a minor fix for the docs to reflect what is in the unit tests. 
I updated Component to use correct (props, children/text) input. 
I think props is needed so that picostyle generated class is added to the underlying h1 element. 
Hardcoded object literal doesn't allow to set a unique style identifier.