### PR TITLE
picostyle enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Picostyle is a 0.4 KB CSS-in-JS library for use with frameworks that expose an `h` function.
 
+Update: Picostyle is now faster by removing JSON.stringify and supports a new css function that returns a class name for Components that support a class attribute property.
+
 [Try it Online](https://codepen.io/morishitter/pen/aEpGYN?editors=0010)
 
 - **🚀 The smallest CSS-in-JS library**: Only 0.4 KB (minified & gzipped).
@@ -47,11 +49,21 @@ Then find it in `window.picostyle`.
 
 Picostyle will work with any framework that exposes an `h` function. When you pass Picostyle an function `h` it returns a higher order function (HOF) that you can use exactly like the `h` you pass it.
 
+Picostyle can now return an object with the style function and a new css fucntion when the new "return object" flag is true
+
 ```js
 import { h } from "some-framework"
 import picostyle from "picostyle"
 
 const style = picostyle(h)
+```
+Or
+```js
+import { h } from "some-framework"
+import picostyle from "picostyle"
+
+const returnObject = true
+const { style, css } = picostyle(h, returnObject)
 ```
 
 The HOF accepts a tag name (or an _unstyled_ component) and returns a function that accepts JSON styles.
@@ -68,7 +80,16 @@ const Component = (props, text) => h("h1", props, text)
 const Text = style(Component)({
   color: "#fff",
 })
+
+// Styling a component that supports a class name attribute
+const Component = (state) => (
+  h("h1",
+    { 
+      class: css( { color: "#fff" } )
+    }
+)
 ```
+
 If you want to change the style based on the props, you can do it by passing a function, instead of JSON styles.
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function parse(obj, isInsideObj) {
 
 export default function(h, retObj) {
   var cache = {}
-  return retObj ? { style, css } : style
+  return retObj ? { style: style, css: css } : style
   function style(nodeName) {
     return function (decls) {
       return function(attributes, children) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,9 @@ function hyphenate(str) {
 
 function createStyle(rules, isKeyframes) {
   var id = "p" + _id++
-  var prefix = (isKeyframes ? "@keyframes " : ".") + id 
+  var name = (isKeyframes ? "@keyframes " : ".") + id 
   rules.forEach(function (rule){
-    sheet.insertRule(prefix + rule, sheet.cssRules.length)
+    sheet.insertRule(name + rule, sheet.cssRules.length)
   })
   return id
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ function hyphenate(str) {
 
 function createStyle(rules, prefix) {
   var id = "p" + _id++
-  var name = prefix + id 
-  rules.forEach(function (rule) {
+  var name = prefix + id
+  rules.forEach(function(rule) {
     if (/^@/.test(rule)) {
       var start = rule.indexOf("{") + 1
       rule = rule.slice(0, start) + name + rule.slice(start)
@@ -33,10 +33,8 @@ function parse(obj, isInsideObj) {
     // Same as typeof value === 'object', but smaller
     if (!value.sub && !Array.isArray(value)) {
       // replace & in "&:hover", "p>&"
-      prop = prop.replace(/&/g, '')
-      arr.push(
-        wrap(parse(value, 1 && !/^@/.test(prop)).join(""), prop)
-      )
+      prop = prop.replace(/&/g, "")
+      arr.push(wrap(parse(value, 1 && !/^@/.test(prop)).join(""), prop))
     } else {
       value = Array.isArray(value) ? value : [value]
       value.forEach(function(value) {
@@ -45,7 +43,7 @@ function parse(obj, isInsideObj) {
     }
   }
   if (!isInsideObj) {
-    arr[0] = wrap(arr[0], '')
+    arr[0] = wrap(arr[0], "")
   }
   return arr
 }
@@ -54,7 +52,7 @@ export default function(h, retObj) {
   var cache = {}
   return retObj ? { style: style, css: css } : style
   function style(nodeName) {
-    return function (decls) {
+    return function(decls) {
       return function(attributes, children) {
         attributes = attributes || {}
         children = attributes.children || children
@@ -66,7 +64,7 @@ export default function(h, retObj) {
       }
     }
   }
-  function css(decls){
+  function css(decls) {
     var rules = parse(decls)
     var key = rules.join("")
     return cache[key] || (cache[key] = createStyle(rules, "."))
@@ -74,6 +72,6 @@ export default function(h, retObj) {
 }
 
 export function keyframes(obj) {
-  var rule = wrap(parse(obj, 1).join(""),"")
+  var rule = wrap(parse(obj, 1).join(""), "")
   return createStyle([rule], "@keyframes ")
 }

--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,10 @@ function parse(obj, isInsideObj) {
   return arr
 }
 
-export default function(h, retObj) {
+export default function(h, options) {
   var cache = {}
-  return retObj ? { style: style, css: css } : style
+  options = options || {}
+  return options.returnObject ? { style: style, css: css } : style
   function style(nodeName) {
     return function(decls) {
       return function(attributes, children) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,17 @@ function hyphenate(str) {
   return str.replace(/[A-Z]/g, "-$&").toLowerCase()
 }
 
-function createStyle(rules, isKeyframes) {
+function createStyle(rules, prefix) {
   var id = "p" + _id++
-  var name = (isKeyframes ? "@keyframes " : ".") + id 
-  rules.forEach(function (rule){
-    sheet.insertRule(name + rule, sheet.cssRules.length)
+  var name = prefix + id 
+  rules.forEach(function (rule) {
+    if (/^@/.test(rule)) {
+      var start = rule.indexOf("{") + 1
+      rule = rule.slice(0, start) + name + rule.slice(start)
+    } else {
+      rule = name + rule
+    }
+    sheet.insertRule(rule, sheet.cssRules.length)
   })
   return id
 }
@@ -63,11 +69,11 @@ export default function(h, retObj) {
   function css(decls){
     var rules = parse(decls)
     var key = rules.join("")
-    return cache[key] || (cache[key] = createStyle(rules, 0))
+    return cache[key] || (cache[key] = createStyle(rules, "."))
   }
 }
 
 export function keyframes(obj) {
   var rule = wrap(parse(obj, 1).join(""),"")
-  return createStyle([rule], 1)
+  return createStyle([rule], "@keyframes ")
 }


### PR DESCRIPTION
closes #57 

Changes:
The key for cache is now based on the css rules created from the parsed object instead of JSON.stringify.
Added a new css function for components that support the class attribute.
Backwards compatible.

The only thing I haven't tested is the removal of:
if (/^(:|>|\.|\*)/.test(prop)) {