### PR TITLE
feat: Adds csstype

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "tslint": "^5.12.0",
     "typescript": "^3.2.2"
   },
+  "optionalDependencies": {
+    "csstype": "^2.6.9"
+  },
   "size-limit": [
     {
       "path": "dist/picostyle.js",

--- a/picostyle.d.ts
+++ b/picostyle.d.ts
@@ -9,15 +9,20 @@ interface VNode<Attributes = {}> {
     key: string;
 }
 
+interface NestedStyles {
+  [key: string]: Styles;
+}
+
 type Component<Attributes = {}> = (attributes: Attributes, children: Array<VNode | string>) => VNode<Attributes>;
 
 type createNode = <Attributes>(nodeName: Component<Attributes> | string,
                                attributes?: Attributes | null,
                                ...children: Array<Children | Children[]>) => VNode<Attributes>;
 
-type StyleProps = (props: any) => Styles;
+type StyleProps = (props: any) => Styles | NestedStyles;
+type StyleObject = Styles | StyleProps | NestedStyles;
 
 export const keyframes: (obj: StyleProps) => string;
 
 export default function picostyle(vdom: createNode): (element: string | Component<object>) =>
-    (styles: Styles | StyleProps) => (...children: any[]) => VNode | string | number | null;
+    (styles: StyleObject) => (...children: any[]) => VNode | string | number | null;

--- a/picostyle.d.ts
+++ b/picostyle.d.ts
@@ -1,3 +1,5 @@
+import { Properties as Styles } from "csstype";
+
 export type Children = VNode | string | number | null;
 
 interface VNode<Attributes = {}> {
@@ -9,17 +11,11 @@ interface VNode<Attributes = {}> {
 
 type Component<Attributes = {}> = (attributes: Attributes, children: Array<VNode | string>) => VNode<Attributes>;
 
-type Keys = string;
-
 type createNode = <Attributes>(nodeName: Component<Attributes> | string,
                                attributes?: Attributes | null,
                                ...children: Array<Children | Children[]>) => VNode<Attributes>;
 
 type StyleProps = (props: any) => Styles;
-
-interface Styles {
-    [key: string]: any;
-}
 
 export const keyframes: (obj: StyleProps) => string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,6 +1883,11 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
@@ -6589,11 +6594,6 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-
-ultradom@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/ultradom/-/ultradom-4.0.2.tgz#8db02eb50ba4ccf0d9b308bf2cc2beefe0dc7745"
-  integrity sha512-k7WQy//ObIa2NLOB6F//drtBGyLNK0pDo5XeVA37FkQhdcw0FYwEt2sRk3W914emdeuRi5OKfDAk87zDNAfu0g==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
For the TypeScript folk; this'll allow the `style` object to also be strictly typed.

I've marked it as an `optionalDependency` so our non-typescript friends wont pull down extra code.