### PR TITLE
Change returnObject example to correct signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Or
 import { h } from "some-framework"
 import picostyle from "picostyle"
 
-const returnObject = true
-const { style, css } = picostyle(h, returnObject)
+const options = { returnObject: true }
+const { style, css } = picostyle(h, options)
 ```
 
 The HOF accepts a tag name (or an _unstyled_ component) and returns a function that accepts JSON styles.


### PR DESCRIPTION
picostyle function looks for an options object, not a boolean.

https://github.com/morishitter/picostyle/blob/9f4053f806adbedbd7ee916e42f8153fbaccd948/src/index.js#L53-L54